### PR TITLE
Replaced 'char' for 'i', as char is a reserved word

### DIFF
--- a/lib/gsmvalidator.js
+++ b/lib/gsmvalidator.js
@@ -16,8 +16,8 @@ var GSMe = (function () {
   return arr;
 })();
 
-function validateCharacter(char) {
-  return GSM[char] === true;
+function validateCharacter(i) {
+  return GSM[i] === true;
 }
 
 function validateMessage(message) {
@@ -29,8 +29,8 @@ function validateMessage(message) {
   return true;
 }
 
-function validateExtendedCharacter(char) {
-  return GSMe[char] === true;
+function validateExtendedCharacter(i) {
+  return GSMe[i] === true;
 }
 
 module.exports.validateCharacter = validateCharacter;


### PR DESCRIPTION
'char' won't minify nicely, was causing combres to blow up.

Running the browserified code through Googles closure compiler generated the following warnings:

JSC_PARSE_ERROR: Parse error. identifier is a reserved word at line 109 character 35
        function validateCharacter(char) {
                                   ^
JSC_PARSE_ERROR: Parse error. identifier is a reserved word at line 110 character 23
            return GSM[char] === true;
                       ^
JSC_PARSE_ERROR: Parse error. identifier is a reserved word at line 122 character 43
        function validateExtendedCharacter(char) {
                                           ^
JSC_PARSE_ERROR: Parse error. identifier is a reserved word at line 123 character 24
            return GSMe[char] === true;
                        ^