### PR TITLE
Fix GSM Validator for IE7

### DIFF
--- a/lib/gsmsplitter.js
+++ b/lib/gsmsplitter.js
@@ -43,7 +43,7 @@ module.exports.split = function (message, options) {
   }
 
   for (var i = 0, count = message.length; i < count; i++) {
-    var c = message.substr(i, 1);
+    var c = message.charAt(i);
 
     if (!gsmvalidator.validateCharacter(c)) {
       if (isHighSurrogate(c.charCodeAt(0))) {

--- a/lib/gsmsplitter.js
+++ b/lib/gsmsplitter.js
@@ -43,7 +43,7 @@ module.exports.split = function (message, options) {
   }
 
   for (var i = 0, count = message.length; i < count; i++) {
-    var c = message[i];
+    var c = message.substr(i, 1);
 
     if (!gsmvalidator.validateCharacter(c)) {
       if (isHighSurrogate(c.charCodeAt(0))) {

--- a/lib/gsmvalidator.js
+++ b/lib/gsmvalidator.js
@@ -2,7 +2,7 @@ var GSM = (function () {
   var GSM_chars = '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ\x20!"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà\f^{}\\[~]|€';
   var arr = {};
   for (var i = 0; i < GSM_chars.length; i++) {
-    var code = GSM_chars.substr(i, 1).charCodeAt(0);
+    var code = GSM_chars.charCodeAt(i);
     arr[code] = true;
   }
   return arr;
@@ -12,7 +12,7 @@ var GSMe = (function () {
   var GSMe_chars = '\f|^€{}[~]\\';
   var arr = {};
   for (var i = 0; i < GSMe_chars.length; i++) {
-    var code = GSMe_chars.substr(i, 1).charCodeAt(0);
+    var code = GSMe_chars.charCodeAt(i);
     arr[code] = true;
   }
   return arr;
@@ -24,7 +24,7 @@ function validateCharacter(character) {
 
 function validateMessage(message) {
   for (var i = 0; i < message.length; i++) {
-    if (validateCharacter(message.substr(i, 1)))
+    if (validateCharacter(message.charAt(i)))
       continue;
     return false;
   }

--- a/lib/gsmvalidator.js
+++ b/lib/gsmvalidator.js
@@ -2,7 +2,8 @@ var GSM = (function () {
   var GSM_chars = '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ\x20!"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà\f^{}\\[~]|€';
   var arr = {};
   for (var i = 0; i < GSM_chars.length; i++) {
-    arr[GSM_chars[i].charCodeAt(0)] = true;
+    var code = GSM_chars.substr(i, 1).charCodeAt(0);
+    arr[code] = true;
   }
   return arr;
 })();
@@ -11,7 +12,8 @@ var GSMe = (function () {
   var GSMe_chars = '\f|^€{}[~]\\';
   var arr = {};
   for (var i = 0; i < GSMe_chars.length; i++) {
-    arr[GSMe_chars[i].charCodeAt(0)] = true;
+    var code = GSMe_chars.substr(i, 1).charCodeAt(0);
+    arr[code] = true;
   }
   return arr;
 })();
@@ -22,7 +24,7 @@ function validateCharacter(character) {
 
 function validateMessage(message) {
   for (var i = 0; i < message.length; i++) {
-    if (validateCharacter(message[i]))
+    if (validateCharacter(message.substr(i, 1)))
       continue;
     return false;
   }

--- a/lib/gsmvalidator.js
+++ b/lib/gsmvalidator.js
@@ -1,23 +1,23 @@
 var GSM = (function () {
   var GSM_chars = '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ\x20!"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà\f^{}\\[~]|€';
-  var arr = [];
+  var arr = {};
   for (var i = 0; i < GSM_chars.length; i++) {
-    arr[GSM_chars[i]] = true;
+    arr[GSM_chars[i].charCodeAt(0)] = true;
   }
   return arr;
 })();
 
 var GSMe = (function () {
   var GSMe_chars = '\f|^€{}[~]\\';
-  var arr = [];
+  var arr = {};
   for (var i = 0; i < GSMe_chars.length; i++) {
-    arr[GSMe_chars[i]] = true;
+    arr[GSMe_chars[i].charCodeAt(0)] = true;
   }
   return arr;
 })();
 
-function validateCharacter(i) {
-  return GSM[i] === true;
+function validateCharacter(character) {
+  return GSM[character.charCodeAt(0)] === true;
 }
 
 function validateMessage(message) {
@@ -29,8 +29,8 @@ function validateMessage(message) {
   return true;
 }
 
-function validateExtendedCharacter(i) {
-  return GSMe[i] === true;
+function validateExtendedCharacter(character) {
+  return GSMe[character.charCodeAt(0)] === true;
 }
 
 module.exports.validateCharacter = validateCharacter;

--- a/test/gsmvalidator.test.js
+++ b/test/gsmvalidator.test.js
@@ -56,10 +56,19 @@ describe('GSM Validator', function () {
 
   });
 
-  describe('Validating a GSM character with more than one character', function () {
+  describe('Validating a GSM character with more than one character beginning with a GSM character', function () {
+
+    it('should return true', function () {
+      var result = gsmValidator.validateCharacter('EUe');
+      assert.strictEqual(result, true);
+    });
+
+  });
+
+  describe('Validating a GSM character with more than one character beginning with a non-GSM character', function () {
 
     it('should return false', function () {
-      var result = gsmValidator.validateCharacter('EUe');
+      var result = gsmValidator.validateCharacter('ȅUe');
       assert.strictEqual(result, false);
     });
 


### PR DESCRIPTION
This change fixes the GSM Validator for use in IE7 after creating a browserify built script.
It seemed the problem was that IE7 is unable to index an array by a string.

The fix moves from using an array to using an object with character code indexes as properties. This approach was chosen to reduce the need for looping to assert that a character is GSM.